### PR TITLE
chore(ci): update release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
   release:
     types:
       - created
+
+env:
+  PYTHONUNBUFFERED: "1"
+  FORCE_COLOR: "1"
+
 jobs:
   package-goe:
     name: Package GOE artefacts required for installation
@@ -12,8 +17,14 @@ jobs:
         with:
           # Fetch all tags
           fetch-depth: 0
-
-      - name: Set up python
+      
+      - name: Set up JDK & SBT
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 21
+      
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -24,10 +35,13 @@ jobs:
       - name: Building GOE package
         run: make package
 
+      - name: Move package to `dist/`
+        run: mv target/goe_*.tar.gz dist/goe.tar.gz
+
       - uses: actions/upload-artifact@v4
         with:
           name: artifacts
-          path: dist/*.tar.gz
+          path: dist/goe.tar.gz
           if-no-files-found: error
   publish:
     name: Publish release
@@ -38,8 +52,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: artifacts
+          path: dist/goe.tar.gz
 
       - name: Add package to current release
         uses: softprops/action-gh-release@v2
         with:
-          files: goe*.tar.gz
+          files: dist/goe.tar.gz


### PR DESCRIPTION
This PR updates the release process to:

1) Install and configure Java/SBT
2) Rename GOE built package to a static name that can be used as a URL
3) Moved package file to `dist/` and publish as an asset